### PR TITLE
add configure hook for config.txt

### DIFF
--- a/prebuild-meta/meta/hooks/configure
+++ b/prebuild-meta/meta/hooks/configure
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+import os
+import filecmp
+
+BOOT_CONFIG="/boot/uboot/config.txt"
+
+VALID_KEYS=[
+    "disable_overscan",
+    "framebuffer_width",
+    "framebuffer_height",
+    "framebuffer_depth",
+    "framebuffer_ignore_alpha",
+    "overscan_left",
+    "overscan_right",
+    "overscan_top",
+    "overscan_bottom",
+    "overscan_scale",
+    "display_rotate",
+    "hdmi_group",
+    "hdmi_mode",
+    "hdmi_drive",
+    "avoid_warnings",
+    "gpu_mem_256",
+    "gpu_mem_512",
+    "gpu_mem",
+]
+
+def get_pi2_config_items():
+   new_values = {}
+   for k in VALID_KEYS:
+      try:
+         v = subprocess.check_output(["snapctl", "get", "pi2", k])
+      except subprocess.CalledProcessError:
+         continue
+      new_values[k] = v
+   return new_values
+
+
+def write_boot_config(items):
+   lines = []
+   with open(BOOT_CONFIG) as fp:
+      for line in fp.readlines():
+         line = line.strip()
+         for k, v in items:
+            if line.startswith("#{}=".format(k)):
+               line = "{}={}".format(k,v)
+               del items[k]
+            lines.append(line)
+      # leftovers
+      for k,v in items:
+         lines.append("{}={}".format(k,v))
+   with open(BOOT_CONFIG+".tmp", "w") as fp:
+      fp.write("\n".join(lines))
+   if not filecmp.cmp(BOOT_CONFIG+".tmp", BOOT_CONFIG, shallow=False):
+      os.rename(BOOT_CONFIG+".tmp", BOOT_CONFIG)
+
+
+if __name__ == "__main__":
+   items = get_pi2_config_items()
+   write_boot_config(items)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,11 +7,17 @@ type: gadget
 architectures:
   - armhf
 confinement: strict
+slots:
+  boot-config-slot:
+    interface: boot-config
 grade: stable
 parts:
     prebuilt:
         plugin: dump
         source: prebuilt
+    hooks:
+        plugin: dump
+        source: prebuild-meta
     licenses:
         plugin: copy
         files:


### PR DESCRIPTION
This makes progress towards LP: #1587137. 

It allows you to write:
``` 
$ snap set pi2 hdmi_width=1024 html_height=768
```
and the config.txt gets adjusted.

Opening this to get feedback on the approach (some more details in https://trello.com/c/e7VPFAxz)

Open issues:
- the `_` in the config.txt are not legal config options in snap config, so we need to mangle them (or relax our config system)
- it also needs the boot-config interface in snapd 
- it needs a snap-declaration that connects the boot-config to the pi2 gadget snap
- proper tests for configure as this has "brick-your-device" potential
- snapcraft does not yet support `hooks:\n` in snapcraft.yaml

