### PR TITLE
add i2c interfaces

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -90,6 +90,15 @@ slots:
   bcm-gpio-26:
     interface: gpio
     number: 26
+  i2c-0:
+    interface: i2c
+    path: /dev/i2c-0
+  i2c-1:
+    interface: i2c
+    path: /dev/i2c-1
+  i2c-2:
+    interface: i2c
+    path: /dev/i2c-2
 
 grade: stable
 parts:


### PR DESCRIPTION
adds interface i2c-0 to i2c-2 for accessing the /dev/i2c-* devices