### PR TITLE
Adding empty configure hook to enable configuration for gadget

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+# do nothing for now

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: pi2
-version: 16.04-0.19
+version: 16.04-0.20
 summary: Raspberry Pi 2 support package
 description: |
  Support files for booting Raspberry Pi


### PR DESCRIPTION
In order to allow brand store images with standard gadget snap published by Canonical, we need configure support for gadget snap to configure serial vault details.
Gadget snap does not have configure hook so snap set will fail

Configure hook itself does not need to do anything so simple place holder is enough to make snapd happy.

Signed-off-by: Ondrej Kubik ondrej.kubik@canonical.com